### PR TITLE
Makefile: label container volume for SELinux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CRE=${CONTAINER_RUNTIME_ENGINE}
 IMAGE_TAG=cool-brisk-walk-image
 
 container_env: container_image
-	${CRE} run --rm --interactive --tty --volume `pwd`:/sources --workdir="/sources" ${IMAGE_TAG}
+	${CRE} run --rm --interactive --tty --volume `pwd`:/sources:z --workdir="/sources" ${IMAGE_TAG}
 
 container_image: .container_image_id
 .container_image_id: Containerfile


### PR DESCRIPTION
Properly label the volume mount with the ':z' suffix so that 'make env' will work on systems with SELinux security policies (ex: Fedora, RHEL, openSUSE) that prevent containers from accessing files outside of their root, even if mounted via CLI.

Without the suffix, contributors using SELinux will get 'permission denied' errors inside of the container shell.
```bash
/usr/bin/docker run --rm --interactive --tty --volume `pwd`:/sources --workdir="/sources" cool-brisk-walk-image
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
root@3d2146558e99:/sources# make
make: stat: Makefile: Permission denied
make: *** No targets specified and no makefile found.  Stop.
root@3d2146558e99:/sources# 
```

This fix was required for me to use `make env` on my own computer.