### PR TITLE
Makefile: execute make directly during make env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CRE=${CONTAINER_RUNTIME_ENGINE}
 IMAGE_TAG=cool-brisk-walk-image
 
 container_env: container_image
-	${CRE} run --rm --interactive --tty --volume `pwd`:/sources --workdir="/sources" ${IMAGE_TAG}
+	${CRE} run --rm --volume `pwd`:/sources --workdir="/sources" ${IMAGE_TAG} make pdf
 
 container_image: .container_image_id
 .container_image_id: Containerfile

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ Or the shorter: `make pdf`
 If you don't have `pdflatex` in your environment, and don't want to pollute it, you can use
 [containers](https://en.wikipedia.org/wiki/OS-level_virtualization) so long as you have a container
 runtime engine like [`docker`](https://www.docker.com/) or [`podman`](https://podman.io/) on your machine.
-Run `make env` to set up an environment, and `make pdf` inside the container's shell to generate the pdf.
+Run `make env` to set up an environment and generate the pdf.
 Consult the [Makefile](Makefile) for further details (and [Makefile Tutorial](https://makefiletutorial.com/)
 to understand Makefiles in general).


### PR DESCRIPTION
Eliminate the extra step for compiling using a container. Instead run 'make pdf' with no interactive shell and exit immedately on completion. Update the guide in the README to reflect this too.