### PR TITLE
Add (Github) Actions Workflows to automate PDF build and deployment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,25 @@
+Two Actions workflows have been added:
+
+- `container-image.yaml`: This workflow file builds the container image which will be used to build the PDF in.
+- `pdf.yaml`: This workflow builds the PDF using the container image from the previous workflow, and also ships the PDF out to a server (`scp`) if the changes are happening on `master` branch.
+
+The following secrets must be configured in the repository settings, under actions settings, (https://github.com/**USERNAME_HERE**/cool-brisk-walk/settings/secrets/actions) by the repository owner for each of these workflows:
+1. `container-image.yaml`:
+- `REGISTRY_TOKEN`: This should be set to the value of an authentication/access token that has permissions to write to the container registry. The access token is generated from the [repository owner's profile settings](https://github.com/settings/tokens). For Github, 'classic' tokens should be used.
+
+2. `pdf.yaml`:
+The following are the ssh credentials for the machine that the PDF is `scp`-ed to. Pretty self-explanatory.
+- `SSH_USERNAME`
+- `SSH_HOST`
+- `SSH_PORT`
+- `SSH_KEY`: The contents of the SSH private key used to login to the server.
+- `SSH_DESTINATION_DIR`: Not the destination path, but only the destination directory.
+
+Note:
+- After the first run of `container-image.yaml` workflow, a cool-brisk-walk container image will have been uploaded to
+https://github.com/**USERNAME_HERE**/cool-brisk-walk/pkgs/container/cool-brisk-walk from where the image will be downloaded
+during the execution of `pdf.yaml` workflow to build the pdf in. However, it's permissions won't be 'public' yet. So, under
+package settings (https://github.com/users/**USERNAME_HERE**/packages/container/cool-brisk-walk/settings) at least Github
+Actions should be allowed to access the image (or the package could be made public entirely).
+- Because of context availability (https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability),
+'ghcr.io' appears in the workflow files and must be configured in place if a different container registry is to be used.

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -1,0 +1,28 @@
+name: Build Container Image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'Containerfile'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  Build_And_Publish_Container_Image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Modify Containerfile for Actions
+        run: sed --in-place '/^CMD.*/i RUN dnf -y install nodejs git' Containerfile
+      - name: Build Container Image
+        run: docker build --file Containerfile --tag ${{ github.repository }} .
+      - name: Tag Container Image
+        run: docker tag ${{ github.repository }} ${{ env.REGISTRY }}/${{ github.repository }}
+      - name: Login To Registry
+        run: echo ${{ secrets.REGISTRY_TOKEN }} | docker login ${{ env.REGISTRY }} --username ${{ github.repository_owner }} --password-stdin
+      - name: Push Image
+        run: docker push ${{ env.REGISTRY }}/${{ github.repository }}

--- a/.github/workflows/pdf.yaml
+++ b/.github/workflows/pdf.yaml
@@ -1,0 +1,52 @@
+name: Build and ship PDF
+
+on:
+  workflow_run:
+    workflows: [Build Container Image]
+    types: [completed]
+    branches: [master]
+  push:
+    paths:
+      - '*.tex'
+  pull_request_target:
+    paths:
+      - '*.tex'
+
+jobs:
+
+  Build:
+    runs-on: ubuntu-latest
+    container:
+      # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+      image: ${{ format('{0}/{1}', 'ghcr.io', github.repository) }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Build PDF
+        run: make --jobs=2 coolbrisk.pdf
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: coolbriskwalk
+          path: coolbrisk.pdf
+
+  Ship:
+    if: ${{ github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    needs: Build
+    steps:
+      - name: Download Artifacts From Build
+        uses: actions/download-artifact@v3
+        with:
+          name: coolbriskwalk
+      - name: Prepare For Shipping
+        run: mv -v coolbrisk.pdf brisk.pdf # Preserve current URL (http://stephendavies.org/brisk.pdf)
+      - name: Ship
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          username: ${{ secrets.SSH_USERNAME }}
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          key: ${{ secrets.SSH_KEY }}
+          source: "brisk.pdf"
+          target: ${{ secrets.SSH_DESTINATION_DIR }}


### PR DESCRIPTION
`pdf.yaml`: Workflow to build and deploy PDF. Essentially handles what `make coolbrisk.pdf` does, and a bit more.
`container-image.yaml`: Workflow to build container image that is used as the container to build the PDF inside of. Essentially handles what `make env` has been doing so far.

The README.md file in .github/workflows describes the configuration necessary to make this work. Those secrets should be configured before merging this change in.